### PR TITLE
Split hands up so player can have multiple hands

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -8,6 +8,7 @@ import {
 } from './store/actions';
 import HandUtils from './utils/hand';
 import GameUtils from './utils/game';
+import StoreUtils from './store/utils';
 
 class Controller {
   constructor(store) {
@@ -28,19 +29,30 @@ class Controller {
     this.oldState = this.state;
     this.state = this.store.getState();
 
-    if (!this.state.playerStood) {
-      if (HandUtils.getHandValue(this.state.playerCards) >= 21) {
+    if (
+      HandUtils.isBlackjack(this.state.dealerHand) &&
+      !StoreUtils.allPlayerHandsStood(this.state)
+    ) {
+      this.dispatch(stand());
+      return;
+    }
+
+    if (!StoreUtils.allPlayerHandsStood(this.state)) {
+      if (HandUtils.getHandValue(StoreUtils.getPlayerHand(this.state)) >= 21) {
         this.dispatch(stand());
       }
 
       return;
     }
 
-    if (this.state.dealerStood) {
+    if (this.state.dealerHand.stood) {
       return;
     }
 
-    if (this.state.playerStood && HandUtils.getHandValue(this.state.dealerCards) < 17) {
+    if (
+      StoreUtils.allPlayerHandsStood(this.state) &&
+      HandUtils.getHandValue(this.state.dealerHand) < 17
+    ) {
       this.dispatch(drawDealerCard());
 
       return;
@@ -48,7 +60,7 @@ class Controller {
 
     this.dispatch(standDealer());
     this.dispatch(
-      rewardPlayer(GameUtils.scoreRound(this.state.playerCards, this.state.dealerCards))
+      rewardPlayer(GameUtils.scoreRound(StoreUtils.getPlayerHand(this.state, 0), this.state.dealerHand))
     );
   }
 }

--- a/js/game.jsx
+++ b/js/game.jsx
@@ -6,6 +6,7 @@ import Immutable from 'immutable';
 import Hand from './hand';
 import HandUtils from './utils/hand';
 import GameUtils from './utils/game';
+import StoreUtils from './store/utils';
 import {
   drawPlayerCard,
   stand,
@@ -15,8 +16,8 @@ import {
 class Game extends React.Component {
   static get propTypes() {
     return {
-      dealerHand: PropTypes.instanceOf(Immutable.List).isRequired,
-      playerHand: PropTypes.instanceOf(Immutable.List).isRequired,
+      dealerHand: PropTypes.object.isRequired,
+      playerHands: PropTypes.instanceOf(Immutable.List).isRequired,
       stood: PropTypes.bool.isRequired,
       bank: PropTypes.number.isRequired,
 
@@ -33,13 +34,14 @@ class Game extends React.Component {
         <button onClick={this.props.stand}>Stand</button>
         <button onClick={this.props.startNewHand}>Start New Hand</button>
         <br />
-        <Hand cards={this.props.playerHand} />
-        <span>{HandUtils.getHandValue(this.props.playerHand)}</span>
+        {
+          this.props.playerHands.map(hand => { return <Hand key={Math.random()} hand={hand} />; })
+        }
         <br />
-        <Hand cards={this.props.dealerHand} hideInitialCard={!this.props.stood} />
+        <Hand hand={this.props.dealerHand} hideInitialCard={!this.props.stood} />
         <span>{this.props.stood ? HandUtils.getHandValue(this.props.dealerHand) : ''}</span>
         <br />
-        <span>{!this.props.stood ? '' : GameUtils.scoreRound(this.props.playerHand, this.props.dealerHand)}</span>
+        <span>{!this.props.stood ? '' : GameUtils.scoreRound(this.props.playerHands.get(0), this.props.dealerHand)}</span>
         <br />
         <span>{this.props.bank}</span>
       </div>
@@ -48,9 +50,9 @@ class Game extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  playerHand: state.playerCards,
-  dealerHand: state.dealerCards,
-  stood: state.playerStood,
+  playerHands: state.playerHands,
+  dealerHand: state.dealerHand,
+  stood: StoreUtils.getPlayerHand(state).stood,
   bank: state.bank
 });
 

--- a/js/hand.jsx
+++ b/js/hand.jsx
@@ -7,14 +7,17 @@ import Card from './card';
 export default class Hand extends React.Component {
   static get propTypes() {
     return {
-      cards: PropTypes.instanceOf(List),
+      hand: PropTypes.object,
       hideInitialCard: PropTypes.bool
     };
   }
 
   static get defaultProps() {
     return {
-      cards: List(),
+      hand: {
+        cards: List(),
+        stood: false
+      },
       hideInitialCard: false
     };
   }
@@ -22,7 +25,7 @@ export default class Hand extends React.Component {
   render() {
     let hiddenFirst = !this.props.hideInitialCard;
     // TODO: Remove Math.random()
-    return this.props.cards.map((card) => {
+    return this.props.hand.cards.map((card) => {
       const cardElement = (
         <Card key={Math.random()} rank={card.rank} suit={card.suit} hide={!hiddenFirst} />
       );

--- a/js/store/__tests__/utils.test.js
+++ b/js/store/__tests__/utils.test.js
@@ -1,0 +1,106 @@
+import { List } from 'immutable';
+import StoreUtils from '../utils';
+
+const hand1 = { cards: List([{ rank: '2', suit: 'spades' }]), stood: false };
+const hand2 = { cards: List([{ rank: '3', suit: 'spades' }]), stood: false };
+const hand3 = { cards: List([{ rank: '4', suit: 'spades' }]), stood: false };
+const dealerHand = { cards: List([{ rank: '5', suit: 'spades' }]), stood: false };
+
+const standHand = (hand) => Object.assign({}, hand, { stood: true });
+
+const generateStore = (hands, currentPlayerHand = 0, dealerHand = List()) => ({
+  playerHands: List(hands),
+  currentPlayerHand,
+  dealerHand
+});
+
+const storeIndexZero = generateStore([hand1, hand2, hand3], 0, dealerHand);
+const storeIndexOne = generateStore([hand1, hand2, hand3], 1, dealerHand);
+const storeIndexTwo = generateStore([hand1, hand2, hand3], 2, dealerHand);
+
+describe('getPlayerHand()', () => {
+  it('should get the correct hand', () => {
+    expect(StoreUtils.getPlayerHand(storeIndexZero)).toEqual(hand1);
+    expect(StoreUtils.getPlayerHand(storeIndexZero))
+      .toEqual(storeIndexZero.playerHands.get(storeIndexZero.currentPlayerHand));
+
+    expect(StoreUtils.getPlayerHand(storeIndexOne)).toEqual(hand2);
+    expect(StoreUtils.getPlayerHand(storeIndexOne))
+      .toEqual(storeIndexOne.playerHands.get(storeIndexOne.currentPlayerHand));
+
+    expect(StoreUtils.getPlayerHand(storeIndexTwo)).toEqual(hand3);
+    expect(StoreUtils.getPlayerHand(storeIndexTwo))
+      .toEqual(storeIndexTwo.playerHands.get(storeIndexTwo.currentPlayerHand));
+  });
+
+  it('should get different hand if specified', () => {
+    expect(StoreUtils.getPlayerHand(storeIndexOne, 0)).toEqual(hand1);
+    expect(StoreUtils.getPlayerHand(storeIndexOne, 1)).toEqual(hand2);
+    expect(StoreUtils.getPlayerHand(storeIndexOne, 2)).toEqual(hand3);
+  });
+});
+
+describe('setPlayerHandInList()', () => {
+  it('should set new player hand', () => {
+    expect(StoreUtils.setPlayerHandInList(storeIndexZero, 'TEST'))
+      .toEqual(List(['TEST', hand2, hand3]));
+    expect(StoreUtils.setPlayerHandInList(storeIndexOne, 'TEST'))
+      .toEqual(List([hand1, 'TEST', hand3]));
+    expect(StoreUtils.setPlayerHandInList(storeIndexTwo, 'TEST'))
+      .toEqual(List([hand1, hand2, 'TEST']));
+  });
+});
+
+describe('addCardToPlayerHand()', () => {
+  it('should add card to end of hand', () => {
+    expect(
+      StoreUtils
+        .addCardToPlayerHand(storeIndexZero, 'TEST')
+        .get(storeIndexZero.currentPlayerHand)
+        .cards
+    ).toEqual(hand1.cards.push('TEST'));
+  });
+});
+
+describe('standPlayerHand()', () => {
+  it('should stand current player hand', () => {
+    expect(StoreUtils.standPlayerHand(storeIndexOne).get(storeIndexOne.currentPlayerHand).stood)
+      .toEqual(true);
+  });
+
+  it('should not stand any other hands', () => {
+    expect(StoreUtils.standPlayerHand(storeIndexTwo).get(0).stood).toEqual(false);
+    expect(StoreUtils.standPlayerHand(storeIndexTwo).get(1).stood).toEqual(false);
+  });
+});
+
+describe('standDealerHand()', () => {
+  it('should stand dealer hand', () => {
+    expect(storeIndexOne.dealerHand.stood).toEqual(false);
+    expect(StoreUtils.standDealerHand(storeIndexOne).stood).toEqual(true);
+  });
+});
+
+describe('allPlayerHandsStood()', () => {
+  const testListAndExpect = (list, expectToBe) => {
+    it('should give ${expectToBe} on ${list}', () => {
+      expect(StoreUtils.allPlayerHandsStood(generateStore(list))).toEqual(expectToBe);
+    });
+  }
+
+  testListAndExpect([], true);
+  testListAndExpect([hand1], false);
+  testListAndExpect([standHand(hand1)], true);
+  testListAndExpect([hand1, hand2], false);
+  testListAndExpect([standHand(hand1), hand2], false);
+  testListAndExpect([hand1, standHand(hand2)], false);
+  testListAndExpect([standHand(hand1), standHand(hand2)], true);
+  testListAndExpect([hand1, hand2, hand3], false);
+  testListAndExpect([hand1, hand2, standHand(hand3)], false);
+  testListAndExpect([hand1, standHand(hand2), hand3], false);
+  testListAndExpect([hand1, standHand(hand2), standHand(hand3)], false);
+  testListAndExpect([standHand(hand1), hand2, hand3], false);
+  testListAndExpect([standHand(hand1), hand2, standHand(hand3)], false);
+  testListAndExpect([standHand(hand1), standHand(hand2), hand3], false);
+  testListAndExpect([standHand(hand1), standHand(hand2), standHand(hand3)], true);
+});

--- a/js/store/default-state.js
+++ b/js/store/default-state.js
@@ -1,11 +1,16 @@
 import { List } from 'immutable';
 
 export default {
-  playerCards: List(),
-  dealerCards: List(),
+  playerHands: List([{
+    cards: List(),
+    stood: false
+  }]),
+  currentPlayerHand: 0,
+  dealerHand: {
+    cards: List(),
+    stood: false
+  },
   shoe: List(),
-  playerStood: false,
-  dealerStood: false,
   numberOfDecks: 8,
   bank: 10000,
   betSize: 10

--- a/js/store/utils.js
+++ b/js/store/utils.js
@@ -1,0 +1,40 @@
+export default class StoreUtils {
+  static getPlayerHand(store, index = store.currentPlayerHand) {
+    return store.playerHands.get(index);
+  }
+
+  static setPlayerHandInList(store, changeTo) {
+    return store.playerHands.set(store.currentPlayerHand, changeTo);
+  }
+
+  static addCardToPlayerHand(store, card) {
+    return StoreUtils.setPlayerHandInList(
+      store,
+      Object.assign(
+        {},
+        StoreUtils.getPlayerHand(store),
+        { cards: StoreUtils.getPlayerHand(store).cards.push(card) }
+      )
+    );
+  }
+
+  static standPlayerHand(store) {
+    return StoreUtils.setPlayerHandInList(
+      store,
+      Object.assign({}, StoreUtils.getPlayerHand(store), { stood: true })
+    );
+  }
+
+  static standDealerHand(store) {
+    return Object.assign({}, store.dealerHand, {
+      stood: true
+    });
+  }
+
+  static allPlayerHandsStood(store) {
+    return store.playerHands.reduce(
+      (allStoodSoFar, hand) => allStoodSoFar && hand.stood,
+      true
+    );
+  }
+}

--- a/js/utils/__tests__/game.test.js
+++ b/js/utils/__tests__/game.test.js
@@ -1,17 +1,13 @@
-import CardUtils from '../card';
+import HandUtils from '../hand';
 import GameUtils from '../game';
 import { List } from 'immutable';
 
-const generateHand = (ranks) => {
-  return List(ranks.map(rank => CardUtils.generateCard(rank)));
-};
-
-const blackjack = generateHand(['A', 'K']);
-const five = generateHand(['2', '3']);
-const fifteen = generateHand(['10', '5']);
-const twenty = generateHand(['J', 'Q']);
-const twentyone = generateHand(['4', '6', 'A']);
-const bust = generateHand(['10', '6', '7']);
+const blackjack = HandUtils.generateHand(['A', 'K']);
+const five = HandUtils.generateHand(['2', '3']);
+const fifteen = HandUtils.generateHand(['10', '5']);
+const twenty = HandUtils.generateHand(['J', 'Q']);
+const twentyone = HandUtils.generateHand(['4', '6', 'A']);
+const bust = HandUtils.generateHand(['10', '6', '7']);
 
 const expectScoreToBe = (player, dealer, score) => {
   expect(GameUtils.scoreRound(player, dealer)).toEqual(GameUtils.HAND_RESULTS[score]);

--- a/js/utils/__tests__/hand.test.js
+++ b/js/utils/__tests__/hand.test.js
@@ -2,27 +2,33 @@ import CardUtils from '../card';
 import HandUtils from '../hand';
 import { List } from 'immutable';
 
+const expectHandToEqual = (cards, expectedStood = false) => {
+  expect(HandUtils.generateHand(cards)).toEqual({
+    cards: List(cards.map(card => CardUtils.generateCard(card))),
+    stood: expectedStood
+  });
+}
+
 describe('generateHand()', () => {
   it('generates empty hand', () => {
-    expect(HandUtils.generateHand(List())).toEqual(List());
+    expectHandToEqual([]);
   });
 
   it('generates single card hand', () => {
-    expect(HandUtils.generateHand(List(['5']))).toEqual(List([CardUtils.generateCard('5')]));
+    expectHandToEqual(['5']);
   });
 
   it('generates multiple card hand', () => {
-    expect(
-      HandUtils.generateHand(List(['2', '3', 'A']))
-    ).toEqual(
-      List([CardUtils.generateCard('2'), CardUtils.generateCard('3'), CardUtils.generateCard('A')])
-    );
+    expectHandToEqual(['2', '3', 'A']);
   });
 });
 
 const expectMaxHandValueOfToBe = (listOfRanks, toBe) => {
   expect(
-    HandUtils.getMaxHandValue(List(listOfRanks.map((rank) => CardUtils.generateCard(rank))))
+    HandUtils.getMaxHandValue({
+      cards: List(listOfRanks.map((rank) => CardUtils.generateCard(rank))),
+      stood: false
+    })
   ).toEqual(toBe);
 }
 
@@ -53,7 +59,10 @@ describe('getMaxHandValue()', () => {
 
 const expectHandValueOfToBe = (listOfRanks, toBe) => {
   expect(
-    HandUtils.getHandValue(List(listOfRanks.map((rank) => CardUtils.generateCard(rank))))
+    HandUtils.getHandValue({
+      cards: List(listOfRanks.map((rank) => CardUtils.generateCard(rank))),
+      stood: false
+    })
   ).toEqual(toBe);
 };
 
@@ -86,7 +95,7 @@ describe('getHandValue()', () => {
 });
 
 const expectIsBlackjackToBe = (hand, isBlackjack) => {
-  expect(HandUtils.isBlackjack(List(HandUtils.generateHand(hand)))).toEqual(isBlackjack);
+  expect(HandUtils.isBlackjack(HandUtils.generateHand(hand))).toEqual(isBlackjack);
 };
 
 describe('isBlackjack()', () => {

--- a/js/utils/card.js
+++ b/js/utils/card.js
@@ -9,17 +9,9 @@ export default class CardUtils {
     return ['clubs', 'diamonds', 'hearts', 'spades'];
   }
 
-  // If the suit is unspecified, just go with spades, as it doesn't matter
-  static generateCard(rank, suit) {
+  static generateCard(rank, suit = 'spades') {
     if (CardUtils.ranks.indexOf(rank) === -1) {
       throw new Error('Invalid card rank');
-    }
-
-    if (suit === undefined) {
-      return {
-        rank,
-        suit: 'spades'
-      };
     }
 
     if (CardUtils.suits.indexOf(suit) === -1) {

--- a/js/utils/hand.js
+++ b/js/utils/hand.js
@@ -1,17 +1,25 @@
 import CardUtils from './card';
+import { List } from 'immutable';
 
 export default class HandUtils {
   static generateHand(hand) {
-    return hand.map(card => CardUtils.generateCard(card));
+    return {
+      cards: List(hand.map(card => CardUtils.generateCard(card))),
+      stood: false
+    }
   }
 
   static getMaxHandValue(hand) {
-    return hand.reduce((sum, card) => sum + CardUtils.getCardValue(card), 0);
+    if (hand.cards.size === 0) {
+      return 0;
+    }
+
+    return hand.cards.reduce((sum, card) => sum + CardUtils.getCardValue(card), 0);
   }
 
   static getHandValue(hand) {
     let maxHandValue = HandUtils.getMaxHandValue(hand);
-    let numberOfAces = hand
+    let numberOfAces = hand.cards
       .map(card => card.rank === 'A')
       .reduce((sum, isAce) => sum + Number(isAce), 0);
 
@@ -24,6 +32,6 @@ export default class HandUtils {
   }
 
   static isBlackjack(hand) {
-    return hand.size === 2 && HandUtils.getHandValue(hand) === 21;
+    return hand.cards.size === 2 && HandUtils.getHandValue(hand) === 21;
   }
 }


### PR DESCRIPTION
If the player is to be allowed to split, they must be able to control
multiple hands of cards. Each has their own stood functionality, and
each can win and requires bets. This meant a bunch of reworking of the
store, but it's all ready now.